### PR TITLE
Toolchain path is one folder up from swift bin path

### DIFF
--- a/src/debugger/lldb.ts
+++ b/src/debugger/lldb.ts
@@ -27,6 +27,7 @@ import { SwiftToolchain } from "../toolchain/toolchain";
  * @returns Library path for LLDB
  */
 export async function getLLDBLibPath(toolchain: SwiftToolchain): Promise<Result<string>> {
+    // can't use toolchain path here as LLDB is not in macOS toolchain path
     const executable = path.join(toolchain.swiftFolderPath, "lldb");
     let pathHint = path.dirname(toolchain.swiftFolderPath);
     try {

--- a/src/toolchain/Sanitizer.ts
+++ b/src/toolchain/Sanitizer.ts
@@ -25,12 +25,12 @@ export class Sanitizer {
         }
     }
 
-    /** Return runtime environment variables */
+    /** Return runtime environment variables for macOS */
     get runtimeEnvironment(): Record<string, string> | undefined {
         if (!this.toolchain.toolchainPath) {
             return undefined;
         }
-        const lib = `/usr/lib/swift/clang/lib/darwin/libclang_rt.${this.clangName}_osx_dynamic.dylib`;
+        const lib = `/lib/swift/clang/lib/darwin/libclang_rt.${this.clangName}_osx_dynamic.dylib`;
         const libFullPath = path.join(this.toolchain.toolchainPath, lib);
         return { DYLD_INSERT_LIBRARIES: libFullPath };
     }

--- a/src/toolchain/toolchain.ts
+++ b/src/toolchain/toolchain.ts
@@ -82,11 +82,11 @@ export function getDarwinTargetTriple(target: DarwinCompatibleTarget): string | 
 
 export class SwiftToolchain {
     constructor(
-        public swiftFolderPath: string,
-        public toolchainPath: string,
-        public swiftVersionString: string,
-        public swiftVersion: Version,
-        public runtimePath?: string,
+        public swiftFolderPath: string, // folder swift executable in $PATH was found in
+        public toolchainPath: string, // toolchain folder. One folder up from swift bin folder. This is to support toolchains without usr folder
+        public swiftVersionString: string, // Swift version as a string, including description
+        public swiftVersion: Version, // Swift version as semVar variable
+        public runtimePath?: string, // runtime library included in output from `swift -print-target-info`
         private defaultTarget?: string,
         private defaultSDK?: string,
         private customSDK?: string,
@@ -179,7 +179,7 @@ export class SwiftToolchain {
     public getToolchainExecutable(exe: string): string {
         // should we add `.exe` at the end of the executable name
         const windowsExeSuffix = process.platform === "win32" ? ".exe" : "";
-        return `${this.toolchainPath}/usr/bin/${exe}${windowsExeSuffix}`;
+        return `${this.toolchainPath}/bin/${exe}${windowsExeSuffix}`;
     }
 
     logDiagnostics(channel: SwiftOutputChannel) {
@@ -286,10 +286,10 @@ export class SwiftToolchain {
                         env: configuration.swiftEnvironmentVariables,
                     });
                     const swift = stdout.trimEnd();
-                    return path.dirname(path.dirname(path.dirname(swift)));
+                    return path.dirname(path.dirname(swift));
                 }
                 default: {
-                    return path.dirname(path.dirname(swiftPath));
+                    return path.dirname(swiftPath);
                 }
             }
         } catch {


### PR DESCRIPTION
Previously it was two folders up and swift executables were assumed to be in a `usr/bin` folder relative to the toolchain folder. It looks like this cannot be assumed. The arm64 toolchains generated by @futurejones are installed at `/usr/libexec/swift` and have their binaries folder in `/usr/libexec/swift/bin`. So the toolchain path is now set to one folder up instead and the binaries folder is set to be in `bin` relative to this folder.

I have checked the sourcekit-lsp code to see if it is happy with this as a valid toolchain path. It appears to be, but will verify with developers
